### PR TITLE
docs(development): improve instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,24 @@
 
 Helsinki Design Systems Meetup organized by @viljamis and @mikkohakkinen.
 
-## Start up server on macOS
+## Website development
 
-`python -m SimpleHTTPServer 8000`
+### Local development
+
+Start up development environment server with the following steps.
+
+- Open your terminal window to access command line interface.
+- Go to the directory that contains the Git repository.
+- Start web server from the directory.
+
+### If you have Python 3.x version
+
+```sh
+python -m http.server 8000
+```
+
+### If you have Python 2.x version
+
+```sh
+python -m SimpleHTTPServer 8000
+```


### PR DESCRIPTION
- Improve instructions for starting the local development environment
- Add details on how to run the HTTP server with Python 3.x version

More details:
- https://docs.python.org/3.7/library/http.server.html
- https://stackoverflow.com/questions/7943751/what-is-the-python-3-equivalent-of-python-m-simplehttpserver